### PR TITLE
Respect externally set environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,17 @@ function DotenvPlugin(options) {
 
 DotenvPlugin.prototype.apply = function(compiler) {
   const plugin = Object.keys(this.env).reduce((definitions, key) => {
+    const existing = process.env[key];
+
+    if (existing) {
+      definitions[`process.env.${key}`] = JSON.stringify(existing);
+      return definitions;
+    };
+
     const value = this.env[key];
-    definitions[`process.env.${key}`] = value ? JSON.stringify(value) : 'undefined';
+    if (value) {
+      definitions[`process.env.${key}`] = JSON.stringify(value);
+    }
     return definitions;
   }, {});
 


### PR DESCRIPTION
The existing behaviour means that this plugin only respects things in the .env file and ignores anything in process.env. The expected behaviour as per dotenv is that process.env overrides anything in .env. This makes that happen.

(Dave here, btw)
