### PR TITLE
Allow the path to the .env file to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ const DotenvPlugin = require('webpack-dotenv-plugin');
 module.exports = {
   ...
   plugins: [
-    new DotenvPlugin({ sample: './.env.default' })
+    new DotenvPlugin({
+      sample: './.env.default',
+      path: './.env'
+    })
   ]
   ...
 };

--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ const defaultOptions = {
   path: './.env'
 };
 
-function DotenvPlugin(options = defaultOptions) {
+function DotenvPlugin(options) {
+  options = options || defaultOptions;
+
   dotenv.config(options);
   this.example = dotenv.parse(fs.readFileSync(options.sample));
   this.env = dotenv.parse(fs.readFileSync(options.path));

--- a/index.js
+++ b/index.js
@@ -4,10 +4,15 @@ const DefinePlugin = require('webpack').DefinePlugin;
 
 module.exports = DotenvPlugin;
 
-function DotenvPlugin(options) {
-  dotenv.config(options || {});
+const defaultOptions = {
+  sample: './.env.default',
+  path: './.env'
+};
+
+function DotenvPlugin(options = defaultOptions) {
+  dotenv.config(options);
   this.example = dotenv.parse(fs.readFileSync(options.sample));
-  this.env = dotenv.parse(fs.readFileSync('./.env'));
+  this.env = dotenv.parse(fs.readFileSync(options.path));
 }
 
 DotenvPlugin.prototype.apply = function(compiler) {


### PR DESCRIPTION
My env file is not at `'./.env'` so I was getting errors when running webpack:
`Error: ENOENT: no such file or directory, open './.env'`

This change allows `options.path` to be specified, just like `dotenv` does (https://www.npmjs.com/package/dotenv#path).

Thanks for this plugin! Let me know what you think 🎯 
