### PR TITLE
Move webpack to peerDependencies and update dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   },
   "homepage": "https://github.com/nwinch/webpack-dotenv-plugin#readme",
   "dependencies": {
-    "dotenv-safe": "^2.3.1",
-    "webpack": "^1.13.0"
+    "dotenv-safe": "^2.3.1"
+  },
+  "peerDependencies": {
+    "webpack": ">=1.13.0 <3 || ^2.1.0-beta"
   }
 }


### PR DESCRIPTION
Currently `webpack-dotenv-plugin` declares **webpack "^1.13.0"** as dependency and causes webpack to be re-installed into webpack-dotenv-plugin folder when NPM is not able to find a matching webpack version.

I got into this issue when working with the last webpack "2.1.0-beta.XX" version.

I looked how other Webpack plugins solve this issue, and I found that they usually declare webpack as `peerDependency`. This way NPM just casts a warning message when not able to find a compatible webpack installed.

In this pull request a moved weback into `peerDependencies`, accepting any webpack version between 1.13.0 and 2.x.x.

I'm currently using `webpack-dotenv-plugin` with  webpack 2.1.0-beta.25, without any problem.

Thanks for this smart plugin. Cheers!