### PR TITLE
Update peer dependencies in order to target Webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   },
   "homepage": "https://github.com/nwinch/webpack-dotenv-plugin#readme",
   "dependencies": {
-    "dotenv-safe": "^2.3.1",
-    "webpack": "^1.13.0"
+    "dotenv-safe": "^2.3.1"
+  },
+  "peerDependencies": {
+    "webpack": ">=1.13.0 <3 || ^2.1.0-beta"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "dotenv-safe": "^2.3.1"
   },
   "peerDependencies": {
-    "webpack": ">=1.13.0 <3 || ^2.1.0-beta"
+    "webpack": ">=1.13.0"
   }
 }


### PR DESCRIPTION
I've just opened webpack's peer dependency to `>=1.13.0`. So It should simply target any stable version of Webpack from 1.13.0.

Webpack `beta` and `rc` versions won't be targeted, but I suppose It's no more an issue, now.

Open to any idea/suggestion/perplexity.
Cheers!