### PR TITLE
support multiple .env files

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,24 @@ function DotenvPlugin(options) {
   if (!options.sample) options.sample = './.env.sample';
   if (!options.path) options.path = './.env';
 
-  dotenv.config(options);
+  const dotenvOptions = Object.assign({}, options);
+  if (Array.isArray(dotenvOptions.path)) { dotenvOptions.path = dotenvOptions.path.shift(); }
+
+  dotenv.config(dotenvOptions);
 
   this.example = dotenv.parse(fs.readFileSync(options.sample));
   this.env = {};
-  if (fs.existsSync(options.path)) {
-    this.env = dotenv.parse(fs.readFileSync(options.path));
+  if (typeof options.path === 'string') {
+    if (fs.existsSync(options.path)) {
+      this.env = dotenv.parse(fs.readFileSync(options.path));
+    }
+  } else {
+    var self = this;
+    options.path.forEach(function(element) {
+      if (fs.existsSync(element)) {
+        Object.assign(self.env, dotenv.parse(fs.readFileSync(element)));
+      }
+    });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-dotenv-plugin",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Use dotenv with webpack.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
use case:

```const dotenvPlugin = new DotenvPlugin({
  sample: path.join(__dirname, '_env'),
  path: [
    path.join(__dirname, '.env'),
    dev && path.join(__dirname, '.env.dev'),
    prod && path.join(__dirname, '.env.prod'),
  ].filter(Boolean),
  allowEmptyValues: true,
});
```
