### PR TITLE
Webpack 4 - Tapable.apply deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,5 +37,5 @@ DotenvPlugin.prototype.apply = function(compiler) {
     'process.env': definitions,
   };
 
-  compiler.apply(new DefinePlugin(plugin));
+  new DefinePlugin(plugin).apply(compiler);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-dotenv-plugin",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Use dotenv with webpack.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/nwinch/webpack-dotenv-plugin#readme",
   "dependencies": {
-    "dotenv-safe": "^4.0.4"
+    "dotenv-safe": "^5.0.1"
   },
   "peerDependencies": {
     "webpack": ">=1.13.0"


### PR DESCRIPTION
- Fixed 'DeprecationWarning: Tapable.apply is deprecated. Call apply on the plugin directly instead' warning with webpack 4.x

- Updated dotenv-safe